### PR TITLE
Fix to allow 5 or more audio channels

### DIFF
--- a/timeline/Sequence/Layer/layers/audio/AudioLayerClip.cpp
+++ b/timeline/Sequence/Layer/layers/audio/AudioLayerClip.cpp
@@ -164,7 +164,7 @@ void AudioLayerClip::setupFromSource()
 	if (reader != nullptr)
 	{
 		std::unique_ptr<AudioFormatReaderSource> newSource(new AudioFormatReaderSource(reader, true));
-		transportSource.setSource(newSource.get(), 0, nullptr, reader->sampleRate, 4);
+		transportSource.setSource(newSource.get(), 0, nullptr, reader->sampleRate, reader->numChannels);
 		readerSource.reset(newSource.release());
 		sampleRate = reader->sampleRate;
 		clipDuration = reader->lengthInSamples / sampleRate;


### PR DESCRIPTION
First part of the fix for the bug discussed in https://github.com/benkuper/Chataigne/issues/97
The max channel count was 4 for audio layers