### PR TITLE
Add an Evaluate on Set time parameter

### DIFF
--- a/timeline/Sequence/Sequence.cpp
+++ b/timeline/Sequence/Sequence.cpp
@@ -64,6 +64,7 @@ Sequence::Sequence() :
 	autoSnap = addBoolParameter("Auto Snap", "If checked, this will automatically snap when moving items", false);
 
 	evaluateOnSeekAndPlay = addBoolParameter("Evaluate on Seek", "If checked, this will evaluate data (like triggering time triggers) when seeking manually while the sequence is playing. If unchecked, seeking manually will disable temporarily evaluation.", true);
+	evaluateOnSetTime = addBoolParameter("Evaluate on Set time", "If checked, this will evaluate data (like triggering time triggers) when seeking manually even when the sequence is not playing.", false);
 
 	currentTime->unitSteps = fps->intValue();
 	totalTime->unitSteps = fps->intValue();
@@ -354,7 +355,7 @@ void Sequence::onContainerParameterChangedInternal(Parameter* p)
 			//timeAtSetTime = timeIsDrivenByAudio() ? hiResAudioTime : currentTime->floatValue();
 		}
 
-		sequenceListeners.call(&SequenceListener::sequenceCurrentTimeChanged, this, (float)prevTime, isPlaying->boolValue() && (!isSeeking || evaluateOnSeekAndPlay->boolValue()));
+		sequenceListeners.call(&SequenceListener::sequenceCurrentTimeChanged, this, (float)prevTime, isPlaying->boolValue() ? !isSeeking || evaluateOnSeekAndPlay->boolValue() || evaluateOnSetTime->boolValue() : isSeeking && evaluateOnSetTime->boolValue());
 		prevTime = currentTime->floatValue();
 	}
 	else if (p == totalTime)

--- a/timeline/Sequence/Sequence.h
+++ b/timeline/Sequence/Sequence.h
@@ -36,6 +36,7 @@ public:
 	IntParameter * fps;
 	BoolParameter* autoSnap;
 	BoolParameter* evaluateOnSeekAndPlay;
+	BoolParameter* evaluateOnSetTime;
 
 	FloatParameter* bpmPreview;
 	IntParameter * beatsPerBar;


### PR DESCRIPTION
Mostly to address issues like https://github.com/benkuper/Chataigne/issues/215 a new `Evaluate on Set time` parameter is added.

It allows the Triggers to trigger when scrolling thru the sequence or manually syncing from an external source like OSC while the sequence is paused.

![Example of Evaluate on Set time](https://github.com/benkuper/juce_timeline/assets/21125429/b767ebc9-807c-46b3-94aa-86f756e7cf64)
