### PR TITLE
Disable animate on add sequence layers

### DIFF
--- a/timeline/Sequence/Layer/ui/SequenceLayerPanelManagerUI.cpp
+++ b/timeline/Sequence/Layer/ui/SequenceLayerPanelManagerUI.cpp
@@ -12,6 +12,7 @@ SequenceLayerPanelManagerUI::SequenceLayerPanelManagerUI(SequenceLayerManager * 
 	BaseManagerUI<SequenceLayerManager, SequenceLayer, SequenceLayerPanel>("SequenceLayers", _manager)
 {
 	viewport.setScrollBarsShown(false, false, true, false);
+	animateItemOnAdd = false;
 	addExistingItems();
 }
 


### PR DESCRIPTION
The animation causes weird UI bugs when creating a sequence and enabling mini mode on the layers from script.

However if you want to keep the look&feel of animation I'll try to find a script workaround :)