### PR TITLE
UI improvements

### DIFF
--- a/timeline/Sequence/Layer/layers/Block/ui/LayerBlockManagerUI.cpp
+++ b/timeline/Sequence/Layer/layers/Block/ui/LayerBlockManagerUI.cpp
@@ -22,6 +22,7 @@ LayerBlockManagerUI::LayerBlockManagerUI(SequenceLayerTimeline* timeline, LayerB
 	bringToFrontOnSelect = false;
 
 	addItemBT->setVisible(false);
+	setBufferedToImage(true);
 }
 
 LayerBlockManagerUI::~LayerBlockManagerUI()

--- a/timeline/Sequence/Layer/ui/SequenceLayerTimeline.cpp
+++ b/timeline/Sequence/Layer/ui/SequenceLayerTimeline.cpp
@@ -121,7 +121,15 @@ void SequenceLayerTimeline::paintOverChildren(Graphics& g)
 
 void SequenceLayerTimeline::visibilityChanged()
 {
-	if (isVisible()) updateContent();
+	if (!isVisible()) return;
+
+	updateContent();
+	shouldRepaint = true;
+}
+
+void SequenceLayerTimeline::parentSizeChanged()
+{
+	shouldRepaint = true;
 }
 
 SequenceLayerTimeline::TimelineNeedle::TimelineNeedle() :

--- a/timeline/Sequence/Layer/ui/SequenceLayerTimeline.h
+++ b/timeline/Sequence/Layer/ui/SequenceLayerTimeline.h
@@ -40,6 +40,7 @@ public:
     void paintOverChildren(juce::Graphics& g) override;
 
 	virtual void visibilityChanged() override;
+    virtual void parentSizeChanged() override;
     
     class TimelineNeedle :
         public Component

--- a/timeline/Sequence/ui/SequenceEditorView.cpp
+++ b/timeline/Sequence/ui/SequenceEditorView.cpp
@@ -205,3 +205,11 @@ void SequenceEditorView::grabberGrabUpdate(GapGrabber*, int relativeDist)
 	panelWidth += relativeDist;
 	resized();
 }
+
+void SequenceEditorView::grabberGrabEvent(GapGrabber*, bool isGrabbing)
+{
+	for (auto& layerUI : timelineManagerUI.itemsUI)
+	{
+		layerUI->setSeekManipulationMode(isGrabbing);
+	}
+}

--- a/timeline/Sequence/ui/SequenceEditorView.h
+++ b/timeline/Sequence/ui/SequenceEditorView.h
@@ -56,6 +56,7 @@ public:
 
 	// Inherited via Listener
 	virtual void grabberGrabUpdate(GapGrabber *, int relativeDist) override;
+	virtual void grabberGrabEvent(GapGrabber *, bool isGrabbing) override;
 
 
 	JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(SequenceEditorView)


### PR DESCRIPTION
1. Makes the cursor needle go at the correct location when resizing the timeline UI
2. Makes the timelines in minimal mode when resizing the header width
Depends on https://github.com/benkuper/juce_organicui/pull/50
3. Set block layers to use `setBufferedToImage` to avoid redrawing them too often