### PR TITLE
TimelineSeeker optimizations and long triggers

### DIFF
--- a/timeline/Sequence/Layer/layers/Trigger/TimeTrigger.cpp
+++ b/timeline/Sequence/Layer/layers/Trigger/TimeTrigger.cpp
@@ -22,8 +22,10 @@ TimeTrigger::TimeTrigger(StringRef name) :
 	time->defaultUI = FloatParameter::TIME;
 	flagY = addFloatParameter("Flag Y", "Position of the trigger's flag", 0,0,1);
 	isTriggered = addBoolParameter("Is Triggered", "Is this Time Trigger already triggered during this playing ?", false);
+	length = addFloatParameter("Length", "Time before the deactivation of the trigger, put 0 to disable automatic deactivation", 0, 0);
+	length->defaultUI = FloatParameter::TIME;
 	
-	isTriggered->hideInEditor = true;
+	isTriggered->setEnabled(false);
 	isTriggered->isSavable = false;
 }
 
@@ -61,4 +63,24 @@ void TimeTrigger::trigger()
 	if (!enabled->boolValue()) return;
 	isTriggered->setValue(true);
 	triggerInternal();
+}
+
+void TimeTrigger::unTrigger()
+{
+	isTriggered->setValue(false);
+	if (!enabled->boolValue()) return;
+	unTriggerInternal();
+}
+
+void TimeTrigger::setTriggerState(bool state)
+{
+	if(state == isTriggered->boolValue()) return;
+	if(state)
+	{
+		trigger();
+	}
+	else
+	{
+		unTrigger();
+	}
 }

--- a/timeline/Sequence/Layer/layers/Trigger/TimeTrigger.h
+++ b/timeline/Sequence/Layer/layers/Trigger/TimeTrigger.h
@@ -19,6 +19,7 @@ public:
 
 	FloatParameter * time;
 	BoolParameter * isTriggered;
+	FloatParameter * length;
 
 	//ui
 	FloatParameter * flagY;
@@ -31,6 +32,11 @@ public:
 
 	virtual void trigger();
 	virtual void triggerInternal() {}
+
+	virtual void unTrigger();
+	virtual void unTriggerInternal() {}
+
+	void setTriggerState(bool state);
 
 	DECLARE_TYPE("TimeTrigger");
 };

--- a/timeline/Sequence/Layer/layers/Trigger/TimeTriggerManager.h
+++ b/timeline/Sequence/Layer/layers/Trigger/TimeTriggerManager.h
@@ -24,6 +24,8 @@ public:
 	TriggerLayer* layer;
 	Sequence* sequence;
 
+	std::multimap<float, std::pair<TimeTrigger*, bool>> actionsMap;
+
 	virtual void addTriggerAt(float time, float flagYPos);
 
 	void addItemInternal(TimeTrigger* t, var data) override;
@@ -41,7 +43,12 @@ public:
 
 	void onControllableFeedbackUpdate(ControllableContainer* cc, Controllable* c) override;
 
+	void reorderActionsMap();
+	void reorderItems() override;
+
+	void executeTriggersTimespan(float startTime, float endTime, bool forward, bool onlyUntrigger = false);
 	void sequenceCurrentTimeChanged(Sequence* _sequence, float prevTime, bool evaluateSkippedData) override;
+	void sequencePlayStateChanged(Sequence *) override;
 	void sequenceTotalTimeChanged(Sequence*) override;
 	void sequencePlayDirectionChanged(Sequence*) override;
 	void sequenceLooped(Sequence*) override;

--- a/timeline/Sequence/Layer/layers/Trigger/ui/TimeTriggerUI.cpp
+++ b/timeline/Sequence/Layer/layers/Trigger/ui/TimeTriggerUI.cpp
@@ -10,6 +10,9 @@
 
 TimeTriggerUI::TimeTriggerUI(TimeTrigger * _tt) :
 	BaseItemUI<TimeTrigger>(_tt, Direction::NONE),
+	labelWidth(0),
+	triggerWidth(0),
+	startXOffset(0),
 	flagXOffset(0)
 {
 	dragAndDropEnabled = false; //avoid default behavior
@@ -49,11 +52,29 @@ void TimeTriggerUI::paint(Graphics & g)
 		g.fillRect(flagRect);
 	}
 
-	if (item->isTriggered->boolValue()) c = GREEN_COLOR.darker();
+	if(item->isSelected)
+	{
+		c = HIGHLIGHT_COLOR;
+	}
+	else if(item->isPreselected)
+	{
+		c = PRESELECT_COLOR;
+	}
+	else if (item->isTriggered->boolValue())
+	{
+		c = GREEN_COLOR.darker();
+	}
 
-	g.setColour(item->isSelected?HIGHLIGHT_COLOR:item->isPreselected?PRESELECT_COLOR:c.brighter());
+	g.setColour(c.brighter());
 	g.drawRect(flagRect);
-	g.drawVerticalLine(flagXOffset, 0, (float)getHeight());
+	g.drawVerticalLine(startXOffset, 0, (float)getHeight());
+
+	if(triggerWidth > 0)
+	{
+		g.drawVerticalLine(startXOffset + triggerWidth, 0, (float)getHeight());
+		g.setColour(c.interpolatedWith(item->itemColor->getColor(), 0.7f).withAlpha(.4f));
+		g.fillRect(startXOffset + 1, 0, triggerWidth - 1, getHeight());
+	}
 
 }
 
@@ -63,8 +84,10 @@ void TimeTriggerUI::resized()
 
 	int ty = (int)(item->flagY->floatValue()*(getHeight() - 20));
 
-	flagRect = r.translated(0, ty).withHeight(20);
-	lineRect = r.withWidth(6);
+	flagRect = r.translated(flagXOffset, ty).withSize(labelWidth, 20);
+	lineRect = r.translated(startXOffset, 0).withWidth(6);
+	if(labelWidth > 0)
+		lengthRect = r.translated(startXOffset + triggerWidth - 6, 0).withWidth(6);
 
 	Rectangle<int> p = flagRect.reduced(2, 2);
 	if (item->isSelected)
@@ -85,6 +108,7 @@ bool TimeTriggerUI::hitTest(int x, int y)
 {
 	if (flagRect.contains(x, y)) return true;
 	if (lineRect.contains(x, y)) return true;
+	if (labelWidth > 0 && lengthRect.contains(x, y)) return true;
 	return false;
 }
 
@@ -95,7 +119,7 @@ void TimeTriggerUI::updateSizeFromName()
 	{
 		newWidth += 60; //for all the buttons
 	}
-	setSize(newWidth, getHeight());
+	labelWidth = newWidth;
 }
 
 void TimeTriggerUI::mouseDown(const MouseEvent& e)
@@ -106,10 +130,21 @@ void TimeTriggerUI::mouseDown(const MouseEvent& e)
 
 	if (item->isUILocked->boolValue()) return;
 
-	item->setMovePositionReference(true);
-	timeAtMouseDown = item->time->floatValue();
-	posAtMouseDown = getX();
+	float lengthDragPos = startXOffset + triggerWidth;
+	float xCursorPos = e.getPosition().getX();
 
+	if(labelWidth > 0 && lengthRect.contains(e.getPosition()))
+	{
+		draggingLength = true;
+	}
+	else
+	{
+		item->setMovePositionReference(true);
+		draggingLength = false;
+	}
+
+	lengthAtMouseDown = item->length->floatValue();
+	timeAtMouseDown = item->time->floatValue();
 	triggerUIListeners.call(&TimeTriggerUIListener::timeTriggerMouseDown, this, e);
 }
 
@@ -123,6 +158,17 @@ void TimeTriggerUI::mouseDrag(const MouseEvent & e)
 	
 	if (e.mods.isLeftButtonDown())
 	{
+		if(draggingLength != e.mods.isCtrlDown())
+		{
+			setMouseCursor(MouseCursor::LeftRightResizeCursor);
+		}
+		else
+		{
+			setMouseCursor(MouseCursor::UpDownLeftRightResizeCursor);
+		}
+	
+		updateMouseCursor();
+
 		triggerUIListeners.call(&TimeTriggerUIListener::timeTriggerDragged, this, e);
 	}
 
@@ -138,19 +184,50 @@ void TimeTriggerUI::mouseUp(const MouseEvent & e)
 {
 	BaseItemUI::mouseUp(e);
 
-	if (flagYAtMouseDown == item->flagY->floatValue() && timeAtMouseDown == item->time->floatValue()) return;
+	Array<UndoableAction*> actions;
 
-	if (item->selectionManager->currentInspectables.size() >= 2)
+	if(lengthAtMouseDown != item->length->floatValue())
 	{
-		item->addMoveToUndoManager(true);
+		actions.add(item->length->setUndoableValue(lengthAtMouseDown, item->length->floatValue(), true));
+	}
+
+	if (flagYAtMouseDown != item->flagY->floatValue())
+	{
+		actions.add(item->flagY->setUndoableValue(flagYAtMouseDown, item->flagY->floatValue(), true));
+	}
+	
+	if(timeAtMouseDown != item->time->floatValue())
+	{
+		if (item->selectionManager->currentInspectables.size() >= 2)
+		{
+			item->addMoveToUndoManager(true);
+		}
+		else
+		{
+			if (!item->isUILocked->boolValue()) actions.add(item->time->setUndoableValue(timeAtMouseDown, item->time->floatValue(), true));
+		}
+	}
+
+	if(!actions.isEmpty())
+		UndoMaster::getInstance()->performActions("Move Trigger \"" + item->niceName + "\"", actions);
+}
+
+void TimeTriggerUI::mouseMove(const MouseEvent & e)
+{
+	if(item->isUILocked->boolValue())
+	{
+		setMouseCursor(MouseCursor::NormalCursor);
+	}
+	else if((labelWidth > 0 && lengthRect.contains(e.getPosition())) != e.mods.isCtrlDown())
+	{
+		setMouseCursor(MouseCursor::LeftRightResizeCursor);
 	}
 	else
 	{
-		Array<UndoableAction*> actions;
-		actions.add(item->flagY->setUndoableValue(flagYAtMouseDown, item->flagY->floatValue(), true));
-		if (!item->isUILocked->boolValue()) actions.add(item->time->setUndoableValue(timeAtMouseDown, item->time->floatValue(), true));
-		UndoMaster::getInstance()->performActions("Move Trigger \"" + item->niceName + "\"", actions);
+		setMouseCursor(MouseCursor::UpDownLeftRightResizeCursor);
 	}
+
+	updateMouseCursor();
 }
 
 void TimeTriggerUI::containerChildAddressChangedAsync(ControllableContainer * cc)
@@ -161,7 +238,7 @@ void TimeTriggerUI::containerChildAddressChangedAsync(ControllableContainer * cc
 
 void TimeTriggerUI::controllableFeedbackUpdateInternal(Controllable * c)
 {
-	if (c == item->time)
+	if (c == item->time || c == item->length)
 	{
 		triggerUIListeners.call(&TimeTriggerUIListener::timeTriggerTimeChanged, this);
 	} else if (c == item->flagY)

--- a/timeline/Sequence/Layer/layers/Trigger/ui/TimeTriggerUI.h
+++ b/timeline/Sequence/Layer/layers/Trigger/ui/TimeTriggerUI.h
@@ -20,15 +20,20 @@ public:
 	//layout
 	Rectangle<int> flagRect;
 	Rectangle<int> lineRect;
+	Rectangle<int> lengthRect;
 
 	std::unique_ptr<BoolToggleUI> lockUI;
 
 	//interaction
 	float timeAtMouseDown;
-	int posAtMouseDown;
+	float lengthAtMouseDown;
 	float flagYAtMouseDown;
+	bool draggingLength;
 
+	int startXOffset;
 	int flagXOffset; //to avoid end of layer overflow
+	int labelWidth;
+	int triggerWidth;
 
 	void paint(Graphics &g) override;
 	void resized() override;
@@ -40,6 +45,7 @@ public:
 	void mouseDown(const MouseEvent &e) override;
 	void mouseDrag(const MouseEvent &e) override;
 	void mouseUp(const MouseEvent &e) override;
+	void mouseMove(const MouseEvent &e) override;
 
 	void containerChildAddressChangedAsync(ControllableContainer *) override;
 	void controllableFeedbackUpdateInternal(Controllable *) override;

--- a/timeline/Sequence/ui/SequenceTimelineSeeker.h
+++ b/timeline/Sequence/ui/SequenceTimelineSeeker.h
@@ -19,11 +19,21 @@ public:
 	~SeekHandle() {}
 
 	void paint(Graphics &g) override;
-	void resized() override;
+};
+
+class SeekNeedle :
+	public Component
+{
+public:
+	SeekNeedle() {}
+	~SeekNeedle() {}
+
+	void paint(Graphics &g) override;
 };
 
 class SequenceTimelineSeeker :
 	public Component,
+	public UITimerTarget,
 	public ContainerAsyncListener
 {
 public:
@@ -32,6 +42,7 @@ public:
 
 	Sequence * sequence;
 	SeekHandle handle;
+	SeekNeedle needle;
 
 	//interaction
 	Point<float> screenMousePosOnDown; 
@@ -48,6 +59,8 @@ public:
 
 	void paint(Graphics &g) override;
 	void resized() override;
+	void handlePaintTimerInternal() override;
+    void paintOverChildren(juce::Graphics& g) override;
 
 	void mouseDown(const MouseEvent &e) override;
 	void mouseDrag(const MouseEvent &e) override;


### PR DESCRIPTION
1. Optimized draw time for the TimelineSeeker
2. Introducing long Triggers (if you like the concept)
![image](https://github.com/user-attachments/assets/6e9a91a1-429d-4597-ab6e-6067c33425e0)
Triggers now have a "Lenght" attribute, by default set to 0 (which keeps the actual behavior of Triggers).
Long triggers (with a Lenght > 0) are triggering when the cursor is entering at any point of its length, and are untriggered when leaving.
This is particularly useful when having time skips/loops to be sure it is triggered:
![ezgif-2fb143b74e0801](https://github.com/user-attachments/assets/daec3671-7c52-4b6c-858e-ae8063821a1a)
Or this can be useful as a ON/OFF switch
3. Reworked a bit the cursor interactions with Triggers to adapt to long triggers and also generally to make it easier to work with (cursor changing, Alt locks the Y value, ...)
4. Make the "Is Triggered" var showing in UI (but read-only)
5. Add an `unTriggerInternal()` hook to add an action when the trigger is untriggered
6. Few bug fixes

Kind of depends on https://github.com/benkuper/juce_organicui/pull/52 to avoid glitches