### PR TITLE
Fix double menu on AudioClips & optimize TimelineSeeker drawing time

### DIFF
--- a/timeline/Sequence/Layer/layers/audio/ui/AudioLayerClipUI.cpp
+++ b/timeline/Sequence/Layer/layers/audio/ui/AudioLayerClipUI.cpp
@@ -102,10 +102,16 @@ void AudioLayerClipUI::mouseDown(const MouseEvent& e)
 	LayerBlockUI::mouseDown(e);
 	if (e.mods.isRightButtonDown() && (e.eventComponent == this || e.eventComponent == automationUI.get()))
 	{
+		PopupMenu::dismissAllActiveMenus();
 		PopupMenu p;
 		p.addItem(1, "Clear automation editor", automationUI != nullptr);
 		p.addItem(2, "Edit enveloppe automation", automationUI == nullptr);
 		p.addItem(3, "Remove enveloppe automation", clip->volume->controlMode != Parameter::ControlMode::MANUAL);
+		if(automationUI != nullptr)
+		{
+			p.addSeparator();
+			automationUI->keysUI.addMenuExtraItems(p, 4);
+		}
 
 		p.showMenuAsync(PopupMenu::Options(), [this](int result)
 			{
@@ -143,6 +149,11 @@ void AudioLayerClipUI::mouseDown(const MouseEvent& e)
 				case 3:
 					this->setTargetAutomation(nullptr);
 					clip->volume->setControlMode(Parameter::ControlMode::MANUAL);
+					break;
+
+				default:
+					if(result>3)
+						automationUI->keysUI.handleMenuExtraItemsResult(result, 4);
 					break;
 				}
 			}
@@ -191,7 +202,7 @@ void AudioLayerClipUI::setTargetAutomation(ParameterAutomation* a)
 		coreGrabber.setVisible(false);
 		grabber.setVisible(false);
 		loopGrabber.setVisible(false);
-		automationUI->addMouseListener(this, true);
+		automationUI->addMouseListener(this, false);
 		addAndMakeVisible(automationUI.get());
 		resized();
 	}

--- a/timeline/Sequence/ui/SequenceTimelineSeeker.h
+++ b/timeline/Sequence/ui/SequenceTimelineSeeker.h
@@ -19,11 +19,21 @@ public:
 	~SeekHandle() {}
 
 	void paint(Graphics &g) override;
-	void resized() override;
+};
+
+class SeekNeedle :
+	public Component
+{
+public:
+	SeekNeedle() {}
+	~SeekNeedle() {}
+
+	void paint(Graphics &g) override;
 };
 
 class SequenceTimelineSeeker :
 	public Component,
+	public UITimerTarget,
 	public ContainerAsyncListener
 {
 public:
@@ -32,6 +42,7 @@ public:
 
 	Sequence * sequence;
 	SeekHandle handle;
+	SeekNeedle needle;
 
 	//interaction
 	Point<float> screenMousePosOnDown; 
@@ -48,6 +59,8 @@ public:
 
 	void paint(Graphics &g) override;
 	void resized() override;
+	void handlePaintTimerInternal() override;
+    void paintOverChildren(juce::Graphics& g) override;
 
 	void mouseDown(const MouseEvent &e) override;
 	void mouseDrag(const MouseEvent &e) override;


### PR DESCRIPTION
 * Fix another old bug on AudioClip's menus where the menu is opened multiple times
 * Added the option to change all easings on AudioClip's automation
 * Optimize TimelineSeeker drawing time